### PR TITLE
Update de.json

### DIFF
--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -1,7 +1,7 @@
 {
   "@metadata": {
     "authors": ["trzyglow"],
-    "last-updated": "2023-08-07",
+    "last-updated": "2023-08-08",
     "acbr-version": "3.0.0",
     "comments": "Deutsche Lokalisierung",
     "locale": "de",

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -258,8 +258,8 @@
   "tool-shared-modal-title-converting": "Konvertieren",
   "tool-shared-modal-title-creating": "Erstellen",
   "tool-shared-modal-title-searching": "Suchen",
-  "[NEEDS TRANSLATION]tool-shared-modal-title-updating": "Updating",
-  "[NEEDS TRANSLATION]tool-shared-modal-title-saving": "Saving",
+  "tool-shared-modal-title-updating": "Aktualisieren",
+  "tool-shared-modal-title-saving": "Speichern",
   "tool-shared-modal-title-conversion-finished": "Konversion Beendet",
   "tool-shared-modal-title-conversion-canceled": "Konversion Abgebrochen",
   "tool-shared-modal-title-extraction-finished": "Extraktion Beendet",
@@ -362,9 +362,9 @@
   "tool-pre-pdf-library-version-oldest-desc": "Schneller, aber weniger robust",
   "tool-pre-pdf-library-version-newest": "Neuste",
   "tool-pre-pdf-library-version-newest-desc": "Langsamer, aber robuster",
-  "[NEEDS TRANSLATION]tool-pre-advanced-preferences": "Advanced",
-  "[NEEDS TRANSLATION]tool-pre-other-preferences": "Other",
-  "[NEEDS TRANSLATION]tool-pre-tempfolder": "Temp Folder",
+  "tool-pre-advanced-preferences": "Erweitert",
+  "tool-pre-other-preferences": "Andere",
+  "tool-pre-tempfolder": "Temp Ordner",
 
   "tool-hst-title": "Chronik",  
   "tool-hst-button-clear-all": "Chronik Löschen",
@@ -464,9 +464,9 @@
   "tool-sc-title": "Datei Aufteilungs-Werkzeug",
   "tool-sc-number": "Anzahl der Dateien, in die aufgeteilt werden soll",
 
-  "[NEEDS TRANSLATION]tool-cix-title": "ComicInfo.xml Editor",
-  "[NEEDS TRANSLATION]tool-cix-warning-save-update": "This will update the contents of the ComicInfo.xml file inside the comic book with the new data",
-  "[NEEDS TRANSLATION]tool-cix-warning-save-create": "This will create a ComicInfo.xml file inside the comic book containing the supplied data",
-  "[NEEDS TRANSLATION]tool-cix-warning-rar": "RAR files can't be edited",
-  "[NEEDS TRANSLATION]tool-cix-update-pages": "Update Pages"  
+  "tool-cix-title": "ComicInfo.xml Editor",
+  "tool-cix-warning-save-update": "Dies wird den Inhalt der ComicInfo.xml Datei im Comicbuch, mit den neuen Daten aktualisieren",
+  "tool-cix-warning-save-create": "Dies wird eine ComicInfo.xml Datei, mit den bereitgestellten Daten, in dem Comicbuch erstellen",
+  "tool-cix-warning-rar": "RAR Dateien können nicht bearbeitet werden",
+  "tool-cix-update-pages": "Aktualisiere Seiten"  
 }


### PR DESCRIPTION
New Translations

The term for editor (the software) was carried over into german from english,
that's why it differs from the translation where editing was used as a verb.