### PR TITLE
Update README.de.md

### DIFF
--- a/docs/README.de.md
+++ b/docs/README.de.md
@@ -43,7 +43,7 @@ Ein Comicbuch Leser und Konverter für CBZ, CBR, CB7, EPUB und PDF Dateien.
 - 'Breitenanpassung', 'Höhenanpassung' und eine anpassbare 'Höhenskalierung' Seitenansicht
 - Seitenrotation
 - Benutzeroberfläche verfügbar auf:
-  - Englisch, Spanisch, Russisch, Deutsch und Arabisch
+  - Englisch, Spanisch, Russisch, Deutsch, Arabisch und Filipino
 - Automatische Wiederherstellung der vergangenen Sitzung, mit Erinnerung der letzten Seitenposition.
 - Tragbarer Modus (durch das Erstellen einer Datei namens portable.txt im selben Ordner wie die Anwendung)
 - Metadateneditor:


### PR DESCRIPTION
Note:
In german, the standardized language itself is also called "Filipino",
but when used as an adjective (like in the credit section) it switches to "philippinisch".

(a gramatical oddity introduced after the original formal name of the language was adopted into german)