### PR TITLE
Add Github CI & Enable MacOS builds

### DIFF
--- a/.github/workflows/build-acbr.yml
+++ b/.github/workflows/build-acbr.yml
@@ -1,0 +1,285 @@
+name: Build ACBR
+on:
+  workflow_dispatch:
+    inputs:
+      createWindows:
+        description: "Create Windows version"
+        required: true
+        default: true
+        type: boolean
+      createLinux:
+        description: "Create Linux version"
+        required: true
+        default: true
+        type: boolean
+      createMac:
+        description: "Create Mac version"
+        required: true
+        default: true
+        type: boolean
+      includeLinuxDeb:
+        description: "Include Linux .deb in release"
+        required: true
+        default: true
+        type: boolean
+      includeLinuxAppImage:
+        description: "Include Linux .AppImage in release"
+        required: true
+        default: true
+        type: boolean
+      includeMacDmg:
+        description: "Include Mac .dmg in release"
+        required: true
+        default: true
+        type: boolean
+      includeWindowsExe:
+        description: "Include Windows self-extracting .exe in release"
+        required: true
+        default: true
+        type: boolean
+permissions:
+  contents: write
+
+jobs:
+  determine_version:
+    runs-on: ubuntu-24.04
+    outputs:
+      RELEASE_NAME: ${{ steps.set_version.outputs.RELEASE_NAME }}
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20.x"
+          cache: 'npm'
+      - name: Set Name and Version
+        id: set_version
+        shell: bash
+        run: |
+          APP_VERSION=$(jq -r .version package.json)
+          BUILD_DATE=$(date '+%Y%m%d-%H%M%S')
+          if echo "$APP_VERSION" | grep 'alpha'; then
+            NEW_APP_VERSION="${APP_VERSION}-${BUILD_DATE}"
+          else
+            NEW_APP_VERSION="${APP_VERSION}"
+          fi
+          echo "RELEASE_NAME=$NEW_APP_VERSION" >> $GITHUB_OUTPUT
+
+  build:
+    needs: determine_version
+    strategy:
+      matrix:
+        os: [ubuntu-24.04, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20.x"
+          cache: 'npm'
+      - name: Install Dependencies
+        run: npm ci
+      - name: Run Dist (Linux)
+        if: ${{ matrix.os == 'ubuntu-24.04' && github.event.inputs.createLinux == 'true' }}
+        run: npm run dist:linux
+      - name: Run Dist (Windows)
+        if: ${{ matrix.os == 'windows-latest' && github.event.inputs.createWindows == 'true' }}
+        run: npm run dist:windows
+      - name: Run Dist (Mac)
+        if: ${{ matrix.os == 'macos-latest' && github.event.inputs.createMac == 'true' }}
+        run: npm run dist:mac
+      - name: Prepare Files (Linux)
+        if: ${{ matrix.os == 'ubuntu-24.04' && github.event.inputs.createLinux == 'true' }}
+        shell: bash
+        run: |
+          mkdir -p ./dist/ACBR_Linux_deb
+          mv ./dist/*.deb ./dist/ACBR_Linux_deb/ 2>/dev/null || echo "No .deb files found"
+          cp -r licenses ./dist/ACBR_Linux_deb/licenses 2>/dev/null || echo "Failed to copy licenses"
+          cp ./dist/VERSION ./dist/ACBR_Linux_deb/ 2>/dev/null || echo "No VERSION file found"
+          mv ./dist/ACBR_deb.sh ./dist/ACBR_Linux_deb/ACBR.sh 2>/dev/null || echo "No ACBR_deb.sh found"
+
+          mkdir -p ./dist/ACBR_Linux_AppImage
+          mv ./dist/*.AppImage ./dist/ACBR_Linux_AppImage/ 2>/dev/null || echo "No .AppImage files found"
+          cp -r licenses ./dist/ACBR_Linux_AppImage/licenses 2>/dev/null || echo "Failed to copy licenses"
+          mv ./dist/VERSION ./dist/ACBR_Linux_AppImage/ 2>/dev/null || echo "No VERSION file found"
+          mv ./dist/ACBR.sh ./dist/ACBR_Linux_AppImage/ 2>/dev/null || echo "No ACBR.sh found"
+
+          mv ./dist/linux-unpacked ./dist/ACBR_Linux 2>/dev/null || echo "No linux-unpacked directory found"
+          cp -r licenses ./dist/ACBR_Linux/licenses 2>/dev/null || echo "Failed to copy licenses"
+          rm ./dist/ACBR_Linux/LICENSE* 2>/dev/null || true
+      - name: Prepare Files (Windows)
+        if: ${{ matrix.os == 'windows-latest' && github.event.inputs.createWindows == 'true' }}
+        shell: bash
+        run: |
+          mv ./dist/win-unpacked ./dist/ACBR_Windows 2>/dev/null || echo "No winAscertain: win-unpacked not found"
+          cp -r licenses ./dist/ACBR_Windows/licenses 2>/dev/null || echo "Failed to copy licenses"
+          rm ./dist/ACBR_Windows/LICENSE* 2>/dev/null || true
+      - name: Prepare Files (Mac)
+        if: ${{ matrix.os == 'macos-latest' && github.event.inputs.createMac == 'true' }}
+        shell: bash
+        run: |
+          mkdir -p ./dist/ACBR_Mac
+          mv ./dist/*.dmg ./dist/ACBR_Mac/ 2>/dev/null || echo "No .dmg files found"
+          mv ./dist/*.zip ./dist/ACBR_Mac/ 2>/dev/null || echo "No .zip files found"
+          cp -r licenses ./dist/ACBR_Mac/licenses 2>/dev/null || echo "Failed to copy licenses"
+          cp ./dist/mac/VERSION ./dist/ACBR_Mac/ 2>/dev/null || echo "No VERSION file found"
+      - name: Prepare Zips (Linux)
+        if: ${{ matrix.os == 'ubuntu-24.04' && github.event.inputs.createLinux == 'true' }}
+        shell: bash
+        run: |
+          cd ./dist
+          zip -r ACBR_Linux_${{ needs.determine_version.outputs.RELEASE_NAME }}.zip ACBR_Linux 2>/dev/null || echo "Failed to zip ACBR_Linux"
+          if [ "${{ github.event.inputs.includeLinuxAppImage }}" == "true" ]; then
+            zip -r ACBR_Linux_AppImage_${{ needs.determine_version.outputs.RELEASE_NAME }}.zip ACBR_Linux_AppImage 2>/dev/null || echo "Failed to zip ACBR_Linux_AppImage"
+          fi
+          if [ "${{ github.event.inputs.includeLinuxDeb }}" == "true" ]; then
+            zip -r ACBR_Linux_deb_${{ needs.determine_version.outputs.RELEASE_NAME }}.zip ACBR_Linux_deb 2>/dev/null || echo "Failed to zip ACBR_Linux_deb"
+          fi
+      - name: Prepare Zips (Windows)
+        if: ${{ matrix.os == 'windows-latest' && github.event.inputs.createWindows == 'true' }}
+        shell: bash
+        run: |
+          cd ./dist
+          7z a ACBR_Windows_${{ needs.determine_version.outputs.RELEASE_NAME }}.zip ACBR_Windows 2>/dev/null || echo "Failed to zip ACBR_Windows"
+          if [ "${{ github.event.inputs.includeWindowsExe }}" == "true" ]; then
+            7z a -t7z -sfx -m0=lzma2 -mx=9 ACBR_Windows_SelfExtracting_${{ needs.determine_version.outputs.RELEASE_NAME }}.exe ACBR_Windows 2>/dev/null || echo "Failed to create self-extracting EXE"
+          fi
+      - name: Prepare Zips (Mac)
+        if: ${{ matrix.os == 'macos-latest' && github.event.inputs.createMac == 'true'}}
+        shell: bash
+        run: |
+          cd ./dist
+          zip -r ACBR_Mac_${{ needs.determine_version.outputs.RELEASE_NAME }}.zip ACBR_Mac/*.zip 2>/dev/null || echo "Failed to zip ACBR_Mac zip"
+      - name: Upload Linux Zip
+        if: ${{ matrix.os == 'ubuntu-24.04' && github.event.inputs.createLinux == 'true' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ACBR_Linux_${{ needs.determine_version.outputs.RELEASE_NAME }}.zip
+          path: dist/ACBR_Linux_${{ needs.determine_version.outputs.RELEASE_NAME }}.zip
+      - name: Upload Linux AppImage Zip
+        if: ${{ matrix.os == 'ubuntu-24.04' && github.event.inputs.createLinux == 'true' && github.event.inputs.includeLinuxAppImage == 'true' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ACBR_Linux_AppImage_${{ needs.determine_version.outputs.RELEASE_NAME }}.zip
+          path: dist/ACBR_Linux_AppImage_${{ needs.determine_version.outputs.RELEASE_NAME }}.zip
+      - name: Upload Linux Deb Zip
+        if: ${{ matrix.os == 'ubuntu-24.04' && github.event.inputs.createLinux == 'true' && github.event.inputs.includeLinuxDeb == 'true' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ACBR_Linux_deb_${{ needs.determine_version.outputs.RELEASE_NAME }}.zip
+          path: dist/ACBR_Linux_deb_${{ needs.determine_version.outputs.RELEASE_NAME }}.zip
+      - name: Upload Linux AppImage
+        if: ${{ matrix.os == 'ubuntu-24.04' && github.event.inputs.createLinux == 'true' && github.event.inputs.includeLinuxAppImage == 'true' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ACBR_Linux_${{ needs.determine_version.outputs.RELEASE_NAME }}.AppImage
+          path: dist/ACBR_Linux_AppImage/*.AppImage
+      - name: Upload Linux Deb
+        if: ${{ matrix.os == 'ubuntu-24.04' && github.event.inputs.createLinux == 'true' && github.event.inputs.includeLinuxDeb == 'true' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ACBR_Linux_${{ needs.determine_version.outputs.RELEASE_NAME }}.deb
+          path: dist/ACBR_Linux_deb/*.deb
+      - name: Upload Windows Zip
+        if: ${{ matrix.os == 'windows-latest' && github.event.inputs.createWindows == 'true' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ACBR_Windows_${{ needs.determine_version.outputs.RELEASE_NAME }}.zip
+          path: dist/ACBR_Windows_${{ needs.determine_version.outputs.RELEASE_NAME }}.zip
+      - name: Upload Windows Self-Extracting EXE
+        if: ${{ matrix.os == 'windows-latest' && github.event.inputs.createWindows == 'true' && github.event.inputs.includeWindowsExe == 'true' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ACBR_Windows_SelfExtracting_${{ needs.determine_version.outputs.RELEASE_NAME }}.exe
+          path: dist/ACBR_Windows_SelfExtracting_${{ needs.determine_version.outputs.RELEASE_NAME }}.exe
+      - name: Upload Mac Zip
+        if: ${{ matrix.os == 'macos-latest' && github.event.inputs.createMac == 'true' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ACBR_Mac_${{ needs.determine_version.outputs.RELEASE_NAME }}.zip
+          path: dist/ACBR_Mac/*.zip
+      - name: Upload Mac DMG
+        if: ${{ matrix.os == 'macos-latest' && github.event.inputs.createMac == 'true' && github.event.inputs.includeMacDmg == 'true' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ACBR_Mac_${{ needs.determine_version.outputs.RELEASE_NAME }}.dmg
+          path: dist/ACBR_Mac/*.dmg
+      - name: Clean Up Workspace (Linux/macOS)
+        if: runner.os != 'Windows' && always()
+        shell: bash
+        run: rm -rf dist || echo "Cleanup failed"
+      - name: Clean Up Workspace (Windows)
+        if: runner.os == 'Windows' && always()
+        shell: powershell
+        run: |
+          try {
+            Remove-Item -Path dist -Recurse -Force -ErrorAction Stop
+          } catch {
+            Write-Output "Cleanup failed"
+          }
+
+  release:
+    needs: [determine_version, build]
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Download All Artifacts
+        uses: actions/download-artifact@v4
+      - name: Prepare Release Artifacts
+        shell: bash
+        run: |
+          mkdir -p release-artifacts
+          # Include Linux artifacts based on inputs
+          if [ "${{ github.event.inputs.createLinux }}" == "true" ]; then
+            mv ACBR_Linux_${{ needs.determine_version.outputs.RELEASE_NAME }}.zip/ACBR_Linux_${{ needs.determine_version.outputs.RELEASE_NAME }}.zip release-artifacts/ 2>/dev/null || echo "Linux zip not found"
+            if [ "${{ github.event.inputs.includeLinuxAppImage }}" == "true" ]; then
+              # Rename AppImage to include platform
+              for file in ACBR_Linux_${{ needs.determine_version.outputs.RELEASE_NAME }}.AppImage/*.AppImage; do
+                if [ -f "$file" ]; then
+                  mv "$file" "release-artifacts/ACBR_Linux_${{ needs.determine_version.outputs.RELEASE_NAME }}.AppImage"
+                fi
+              done 2>/dev/null || echo "Linux AppImage not found"
+            fi
+            if [ "${{ github.event.inputs.includeLinuxDeb }}" == "true" ]; then
+              # Rename deb to include platform
+              for file in ACBR_Linux_${{ needs.determine_version.outputs.RELEASE_NAME }}.deb/*.deb; do
+                if [ -f "$file" ]; then
+                  mv "$file" "release-artifacts/ACBR_Linux_${{ needs.determine_version.outputs.RELEASE_NAME }}.deb"
+                fi
+              done 2>/dev/null || echo "Linux deb not found"
+            fi
+          fi
+          # Include Windows artifacts based on inputs
+          if [ "${{ github.event.inputs.createWindows }}" == "true" ]; then
+            mv ACBR_Windows_${{ needs.determine_version.outputs.RELEASE_NAME }}.zip/ACBR_Windows_${{ needs.determine_version.outputs.RELEASE_NAME }}.zip release-artifacts/ 2>/dev/null || echo "Windows zip not found"
+            if [ "${{ github.event.inputs.includeWindowsExe }}" == "true" ]; then
+              mv ACBR_Windows_SelfExtracting_${{ needs.determine_version.outputs.RELEASE_NAME }}.exe/ACBR_Windows_SelfExtracting_${{ needs.determine_version.outputs.RELEASE_NAME }}.exe release-artifacts/ 2>/dev/null || echo "Windows self-extracting EXE not found"
+            fi
+          fi
+          # Include Mac artifacts based on inputs
+          if [ "${{ github.event.inputs.createMac }}" == "true" ]; then
+            # Rename Mac zip to include platform
+            for file in ACBR_Mac_${{ needs.determine_version.outputs.RELEASE_NAME }}.zip/*.zip; do
+              if [ -f "$file" ]; then
+                mv "$file" "release-artifacts/ACBR_Mac_${{ needs.determine_version.outputs.RELEASE_NAME }}.zip"
+              fi
+            done 2>/dev/null || echo "Mac zip not found"
+            if [ "${{ github.event.inputs.includeMacDmg }}" == "true" ]; then
+              # Rename dmg to include platform
+              for file in ACBR_Mac_${{ needs.determine_version.outputs.RELEASE_NAME }}.dmg/*.dmg; do
+                if [ -f "$file" ]; then
+                  mv "$file" "release-artifacts/ACBR_Mac_${{ needs.determine_version.outputs.RELEASE_NAME }}.dmg"
+                fi
+              done 2>/dev/null || echo "Mac DMG not found"
+            fi
+          fi
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          prerelease: ${{ contains(needs.determine_version.outputs.RELEASE_NAME, 'alpha') }}
+          draft: true
+          name: v${{ needs.determine_version.outputs.RELEASE_NAME }}
+          tag_name: v${{ needs.determine_version.outputs.RELEASE_NAME }}
+          files: release-artifacts/*

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "3.10.2",
       "license": "BSD-2-Clause",
       "dependencies": {
+        "@emnapi/runtime": "^1.4.4",
         "7zip-bin": "^5.2.0",
         "adm-zip": "^0.5.16",
         "axios": "^1.7.9",
@@ -34,7 +35,7 @@
       },
       "devDependencies": {
         "del-cli": "^6.0.0",
-        "electron": "^33.3.1",
+        "electron": "^37.2.0",
         "electron-builder": "^26.0.11",
         "license-checker": "^25.0.1",
         "shx": "^0.3.4"
@@ -964,11 +965,10 @@
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.3.1.tgz",
-      "integrity": "sha512-kEBmG8KyqtxJZv+ygbEim+KCGtIq1fC22Ms3S4ziXmYKm8uyoLX0MHONVKwp+9opg390VaKRNt4a7A9NwmpNhw==",
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.4.4.tgz",
+      "integrity": "sha512-hHyapA4A3gPaDCNfiqyZUStTMqIkKRshqPIuDOXv1hcBnD4U3l8cP0T1HMCfGRxQ6V64TGCcoswChANyOAwbQg==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -1988,11 +1988,12 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.11.25",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.25.tgz",
-      "integrity": "sha512-TBHyJxk2b7HceLVGFcpAUjsa5zIdsPWlR6XHfyGzd0SFu+/NFgQgMAl96MSDZgQDvJAvV6BKsFOrt6zIL09JDw==",
+      "version": "22.16.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.16.2.tgz",
+      "integrity": "sha512-Cdqa/eJTvt4fC4wmq1Mcc0CPUjp/Qy2FGqLza3z3pKymsI969TcZ54diNJv8UYUgeWxyb8FSbCkhdR6WqmUFhA==",
+      "license": "MIT",
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/plist": {
@@ -3585,14 +3586,14 @@
       }
     },
     "node_modules/electron": {
-      "version": "33.3.1",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-33.3.1.tgz",
-      "integrity": "sha512-Z7l2bVgpdKxHQMI4i0CirBX2n+iCYKOx5mbzNM3BpOyFELwlobEXKmzCmEnwP+3EcNeIhUQyIEBFQxN06QgdIw==",
+      "version": "37.2.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-37.2.0.tgz",
+      "integrity": "sha512-dE6+qeg6SBUVd5d8CD2+GH82kh+gF1v40+hs+U+UOno681NMSGmBtgqwldQRpbvtnQDD7V2M9Cpfr3+Abw7aBg==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@electron/get": "^2.0.0",
-        "@types/node": "^20.9.0",
+        "@types/node": "^22.7.7",
         "extract-zip": "^2.0.1"
       },
       "bin": {
@@ -8556,9 +8557,10 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT"
     },
     "node_modules/unicode-properties": {
       "version": "1.4.1",
@@ -9609,10 +9611,9 @@
       }
     },
     "@emnapi/runtime": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.3.1.tgz",
-      "integrity": "sha512-kEBmG8KyqtxJZv+ygbEim+KCGtIq1fC22Ms3S4ziXmYKm8uyoLX0MHONVKwp+9opg390VaKRNt4a7A9NwmpNhw==",
-      "optional": true,
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.4.4.tgz",
+      "integrity": "sha512-hHyapA4A3gPaDCNfiqyZUStTMqIkKRshqPIuDOXv1hcBnD4U3l8cP0T1HMCfGRxQ6V64TGCcoswChANyOAwbQg==",
       "requires": {
         "tslib": "^2.4.0"
       }
@@ -10230,11 +10231,11 @@
       "dev": true
     },
     "@types/node": {
-      "version": "20.11.25",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.25.tgz",
-      "integrity": "sha512-TBHyJxk2b7HceLVGFcpAUjsa5zIdsPWlR6XHfyGzd0SFu+/NFgQgMAl96MSDZgQDvJAvV6BKsFOrt6zIL09JDw==",
+      "version": "22.16.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.16.2.tgz",
+      "integrity": "sha512-Cdqa/eJTvt4fC4wmq1Mcc0CPUjp/Qy2FGqLza3z3pKymsI969TcZ54diNJv8UYUgeWxyb8FSbCkhdR6WqmUFhA==",
       "requires": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~6.21.0"
       }
     },
     "@types/plist": {
@@ -11380,12 +11381,12 @@
       }
     },
     "electron": {
-      "version": "33.3.1",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-33.3.1.tgz",
-      "integrity": "sha512-Z7l2bVgpdKxHQMI4i0CirBX2n+iCYKOx5mbzNM3BpOyFELwlobEXKmzCmEnwP+3EcNeIhUQyIEBFQxN06QgdIw==",
+      "version": "37.2.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-37.2.0.tgz",
+      "integrity": "sha512-dE6+qeg6SBUVd5d8CD2+GH82kh+gF1v40+hs+U+UOno681NMSGmBtgqwldQRpbvtnQDD7V2M9Cpfr3+Abw7aBg==",
       "requires": {
         "@electron/get": "^2.0.0",
-        "@types/node": "^20.9.0",
+        "@types/node": "^22.7.7",
         "extract-zip": "^2.0.1"
       }
     },
@@ -15067,9 +15068,9 @@
       "dev": true
     },
     "undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="
     },
     "unicode-properties": {
       "version": "1.4.1",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,30 @@
     "win": {
       "icon": "./src/assets/images/icon_256x256.png"
     },
+    "mac": {
+      "category": "Graphics",
+      "icon": "./src/assets/images/icon_512x512.png",
+      "target": [
+        {
+          "target": "dmg",
+          "arch": [
+            "arm64"
+          ]
+        },
+        {
+          "target": "zip",
+          "arch": [
+            "arm64"
+          ]
+        }
+      ],
+      "artifactName": "${name}-${version}.${ext}",
+      "asarUnpack": [
+        "**/node_modules/sharp/**",
+        "**/node_modules/@img/**/*",
+        "**/node_modules/7zip-bin/**"
+      ]
+    },
     "linux": {
       "category": "Graphics",
       "icon": "./src/assets/images/icon_256x256.png",
@@ -40,16 +64,21 @@
     "start:glib": "export G_SLICE=always-malloc && electron . --dev",
     "dist:linux": "npm run 7zbin:linux && npm run build:linux && npm run extras:linux",
     "dist:windows": "npm run build:windows && npm run extras:windows",
+    "dist:mac": "npm run 7zbin:mac && npm run build:mac && npm run extras:mac",
     "dist:cross": "npm run dist:cross-windows && npm run dist:cross-linux",
     "dist:cross-linux": "npm run sharp:linux && npm run dist:linux",
     "dist:cross-windows": "npm run sharp:windows && npm run dist:windows",
     "build:linux": "electron-builder --linux --publish never",
     "build:windows": "electron-builder --win --dir --publish never",
+    "build:mac": "electron-builder --mac --publish never",
     "sharp:windows": "del-cli ./node_modules/sharp && npm install --platform=win32 --arch=x64 sharp",
     "sharp:linux": "del-cli ./node_modules/sharp && npm install --platform=linux --arch=x64 sharp",
+    "sharp:mac": "del-cli ./node_modules/sharp && npm install --platform=darwin --arch=arm64 sharp",
     "7zbin:linux": "shx chmod +x node_modules/7zip-bin/linux/x64/7za",
+    "7zbin:mac": "shx chmod +x node_modules/7zip-bin/mac/x64/7za",
     "extras:linux": "echo '#!/bin/bash\\nexport G_SLICE=always-malloc && ./acbr-comic-book-reader \"$@\"' > ./dist/linux-unpacked/ACBR.sh && shx chmod +x ./dist/linux-unpacked/ACBR.sh && echo '#!/bin/bash\\nexport G_SLICE=always-malloc && ./acbr-comic-book-reader.AppImage \"$@\"' > ./dist/ACBR.sh && shx chmod +x ./dist/ACBR.sh && echo '#!/bin/bash\\nexport G_SLICE=always-malloc && acbr-comic-book-reader \"$@\"' > ./dist/ACBR_deb.sh && shx chmod +x ./dist/ACBR_deb.sh && echo ${npm_package_version} > ./dist/linux-unpacked/VERSION && echo ${npm_package_version} > ./dist/VERSION",
     "extras:windows": "echo %npm_package_version% > ./dist/win-unpacked/VERSION",
+    "extras:mac": "shx mkdir -p ./dist/mac && echo ${npm_package_version} > ./dist/mac/VERSION",
     "licenses": "license-checker > licenses/node_modules.txt && shx sed -i 's/path.*node_modules/path: node_modules/' ./licenses/node_modules.txt && shx sed -i 's/licenseFile.*node_modules/licenseFile: node_modules/' ./licenses/node_modules.txt && npm run localization licenses",
     "localization:update": "node ./tools/localization.js update all",
     "localization:state": "node ./tools/localization.js state all",
@@ -57,12 +86,13 @@
   },
   "devDependencies": {
     "del-cli": "^6.0.0",
-    "electron": "^33.3.1",
+    "electron": "^37.2.0",
     "electron-builder": "^26.0.11",
     "license-checker": "^25.0.1",
     "shx": "^0.3.4"
   },
   "dependencies": {
+    "@emnapi/runtime": "^1.4.4",
     "7zip-bin": "^5.2.0",
     "adm-zip": "^0.5.16",
     "axios": "^1.7.9",

--- a/src/core/main.js
+++ b/src/core/main.js
@@ -204,7 +204,8 @@ if (!gotTheLock) {
       width: settings.getValue("width"),
       height: settings.getValue("height"),
       resizable: true,
-      frame: false,
+      frame: process.platform === "darwin" ? true : false,
+      titleBarStyle: process.platform === "darwin" ? "hidden" : undefined,
       icon: path.join(__dirname, "../assets/images/icon_256x256.png"),
       show: false,
       webPreferences: {

--- a/src/core/preload.js
+++ b/src/core/preload.js
@@ -28,10 +28,18 @@ contextBridge.exposeInMainWorld("ipc", {
 let g_titlebar;
 
 window.addEventListener("DOMContentLoaded", () => {
-  g_titlebar = new CustomTitlebar({
+  const titlebarOptions = {
     icon: "../assets/images/icon_256x256.png",
     titleHorizontalAlignment: "right",
-  });
+  };
+  
+  if (process.platform === "darwin") {
+    titlebarOptions.enableMacOSWindowControls = true;
+    titlebarOptions.windowControlsOnMacOS = true;
+    titlebarOptions.titleHorizontalAlignment = "center";
+  }
+  
+  g_titlebar = new CustomTitlebar(titlebarOptions);
 
   ipcRenderer.on("preload", (event, args) => {
     if (args[0] == "update-menubar") {


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for building and releasing.

I also briefly tried running it on MacOS, and it works. Since the window controls were not visible on Mac previously, I activated them conditionally.

### Build and Release Workflow Enhancements:
* Added a new GitHub Actions workflow (`.github/workflows/build-acbr.yml`) to build and release artifacts for macOS, Linux, and Windows. This includes platform-specific packaging, artifact preparation, and release creation.

### macOS Adjustments:
* Added macOS-specific build and packaging commands (`dist:mac`, `build:mac`, `sharp:mac`, `7zbin:mac`, `extras:mac`) to the `package.json` scripts.
* Modified `src/core/main.js` to enable native macOS window controls (`frame: true`) and hide the title bar (`titleBarStyle: "hidden"`) when running on macOS.
* Updated `src/core/preload.js` to customize the title bar for macOS, enabling native macOS window controls and centering the title.